### PR TITLE
feat: allow to skip publish to official NuGet

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,19 +60,22 @@ The NuGet server authentication is **required** and can be set via [environment 
 
 ### Options
 
-| Options             | Description                                                                                      | Default     |
-| ------------------- | ------------------------------------------------------------------------------------------------ | ----------- |
-| `nugetServer`       | The URL of the NuGet server to push the package to.                                              | `nuget.org` |
-| `projectPath`       | The relative path to the project file to pack. Can also be an array including multiple projects. |             |
-| `includeSymbols`    | If true Debug symbols will be included in the package.                                           | `false`     |
-| `includeSource`     | If true source code will be included in the package.                                             | `false`     |
-| `dotnet`            | The path to the dotnet executable if not in PATH.                                                | `dotnet`    |
-| `publishToGitLab`   | If true, package will also be published to the GitLab registry.                                  | `false`     |
-| `usePackageVersion` | If true, version is directly set via dotnet pack argument.                                       | `false`     |
+| Options              | Description                                                                                                                                                                      | Default     |
+| -------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------- |
+| `nugetServer`        | The URL of the NuGet server to push the package to.                                                                                                                              | `nuget.org` |
+| `projectPath`        | The relative path to the project file to pack. Can also be an array including multiple projects.                                                                                 |             |
+| `includeSymbols`     | If true Debug symbols will be included in the package.                                                                                                                           | `false`     |
+| `includeSource`      | If true source code will be included in the package.                                                                                                                             | `false`     |
+| `dotnet`             | The path to the dotnet executable if not in PATH.                                                                                                                                | `dotnet`    |
+| `publishToGitLab`    | If true, package will also be published to the GitLab registry.                                                                                                                  | `false`     |
+| `usePackageVersion`  | If true, version is directly set via dotnet pack argument.                                                                                                                       | `false`     |
+| `skipPublishToNuget` | If true, the NuGet package will not be published to the `nugetServer`. You can use this together with `publishToGitLab` to **only** publish your package to the GitLab registry. | `false`     |
 
 **Note**: If `usePackageVersion` is set the version from Semantic Release is given directly to the `dotnet pack` command via the `-p:PackageVersion=<version>` argument. In this case any existing version in project files are ignored.
 
 **Note**: If `publishToGitLab` is set the environment variables for `CI_SERVER_URL`, `CI_PROJECT_ID` and `CI_JOB_TOKEN` must be set. If you are running in GitLab CI this is automatically set by GitLab for you.
+
+**Note**: If `skipPublishToNuget` is set the package will not be published to the nuget server even if you specified an alternative via `nugetServer`. This only makes sense in combination with `publishToGitLab`.
 
 **Note**: When you add the [NPM plugin](https://raw.githubusercontent.com/semantic-release/npm) to update your `package.json` you should set `npmPublish` to `false` to prevent Semantic Release from trying to publish an NPM package.
 

--- a/src/UserConfig.ts
+++ b/src/UserConfig.ts
@@ -6,7 +6,10 @@ export interface UserConfig {
   includeSymbols?: boolean;
   /** If true source coe will be included in the package. */
   includeSource?: boolean;
-  /** The name of the registry to push to. */
+  /**
+   * The name of the registry to push to, if empty official NuGet server will be used, unless skipPublishToNuget is set
+   * to true.
+   */
   nugetServer?: string;
   /** The path to the dotnet executable if not in PATH. */
   dotnet?: string;
@@ -14,4 +17,6 @@ export interface UserConfig {
   publishToGitLab?: boolean;
   /** If true, package version is overriden via PackageVersion argument. */
   usePackageVersion?: boolean;
+  /** If true, package will not be published to the official NuGet server. */
+  skipPublishToNuget?: boolean;
 }

--- a/src/publish.ts
+++ b/src/publish.ts
@@ -13,28 +13,32 @@ export const publish = async (pluginConfig: Config & UserConfig, context: Contex
   const baseCliArgs: string[] = ["nuget", "push"];
   const token: string = process.env.NUGET_TOKEN!;
 
-  try {
-    const cliArgs = [...baseCliArgs, "-s", registry, "-k", token];
+  if (pluginConfig.skipPublishToNuget) {
+    context.logger.log("Skipping publish to NuGet server because skipPublishToNuget is set to true.");
+  } else {
+    try {
+      const cliArgs = [...baseCliArgs, "-s", registry, "-k", token];
 
-    cliArgs.push(`${packagePath}/*.nupkg`);
+      cliArgs.push(`${packagePath}/*.nupkg`);
 
-    const argStrings = cliArgs.map((value) => (value === token ? "[redacted]" : value)).join(" ");
-    context.logger.log(`running command "${dotnet} ${argStrings}" ...`);
+      const argStrings = cliArgs.map((value) => (value === token ? "[redacted]" : value)).join(" ");
+      context.logger.log(`running command "${dotnet} ${argStrings}" ...`);
 
-    await execa(dotnet, cliArgs, { stdio: "inherit" });
-  } catch (error) {
-    context.logger.error(`${dotnet} push failed: ${(error as Error).message}`);
+      await execa(dotnet, cliArgs, { stdio: "inherit" });
+    } catch (error) {
+      context.logger.error(`${dotnet} push failed: ${(error as Error).message}`);
 
-    if (typeof error === "object" && (error as ExecaReturnBase<void>).exitCode) {
-      const err = error as ExecaReturnBase<void>;
-      let description = err.command;
+      if (typeof error === "object" && (error as ExecaReturnBase<void>).exitCode) {
+        const err = error as ExecaReturnBase<void>;
+        let description = err.command;
 
-      // hide token from SR output
-      if (err.command && err.command.includes(token)) {
-        description = description.replace(token, "[redacted]");
+        // hide token from SR output
+        if (err.command && err.command.includes(token)) {
+          description = description.replace(token, "[redacted]");
+        }
+
+        throw new SemanticReleaseError(`publish to registry ${registry} failed`, err.exitCode, description);
       }
-
-      throw new SemanticReleaseError(`publish to registry ${registry} failed`, err.exitCode, description);
     }
   }
 

--- a/src/verify.ts
+++ b/src/verify.ts
@@ -18,6 +18,12 @@ export const verify = async (pluginConfig: Config & UserConfig, _: Context): Pro
         errors.push(new Error(`GitLab environment variable ${envVar} is not set.`));
       }
     }
+  } else if (pluginConfig.skipPublishToNuget) {
+    errors.push(
+      new Error(
+        "skipPublishToNuget is set to true, but publishToGitLab is not set to true so the package will not be published anywhere.",
+      ),
+    );
   }
 
   pluginConfig.projectPath = Array.isArray(pluginConfig.projectPath)

--- a/test/publish.test.ts
+++ b/test/publish.test.ts
@@ -124,6 +124,58 @@ describe("publish", () => {
     expect(execaMock).toHaveBeenCalledTimes(1);
   });
 
+  it("should not publish to nugetServer when skipPublishToNuget is true", async () => {
+    await publish(
+      {
+        projectPath: "src/MyProject/MyProject.csproj",
+        skipPublishToNuget: true,
+        publishToGitLab: false,
+      },
+      context,
+    );
+
+    expect(execaMock).not.toHaveBeenCalled();
+  });
+
+  it("should publish to nugetServer when skipPublishToNuget is false", async () => {
+    execaMock.mockImplementationOnce(() => {
+      return {
+        command: "dotnet nuget push -s https://api.nuget.org/v3/index.json -k 104E4 out/*.nupkg",
+        exitCode: 0,
+      } as ExecaReturnBase<string>;
+    });
+
+    await publish(
+      {
+        projectPath: "src/MyProject/MyProject.csproj",
+        skipPublishToNuget: false,
+        publishToGitLab: false,
+      },
+      context,
+    );
+
+    expect(execaMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("should publish to nugetServer when skipPublishToNuget is not set", async () => {
+    execaMock.mockImplementationOnce(() => {
+      return {
+        command: "dotnet nuget push -s https://api.nuget.org/v3/index.json -k 104E4 out/*.nupkg",
+        exitCode: 0,
+      } as ExecaReturnBase<string>;
+    });
+
+    await publish(
+      {
+        projectPath: "src/MyProject/MyProject.csproj",
+        publishToGitLab: false,
+      },
+      context,
+    );
+
+    expect(execaMock).toHaveBeenCalledTimes(1);
+  });
+
   it("should react nuget token from command output", async () => {
     execaMock.mockImplementationOnce(() => {
       return {

--- a/test/verify.test.ts
+++ b/test/verify.test.ts
@@ -85,6 +85,25 @@ describe("verify", () => {
     expect(actualErr?.errors[0].message).toBe("GitLab environment variable CI_JOB_TOKEN is not set.");
   });
 
+  it("should report an error when publishToGitlab is false and skipPublishToNuget is true", async () => {
+    process.env.NUGET_TOKEN = "104E2";
+
+    let actualErr: AggregateError | undefined;
+    try {
+      await verify(
+        { publishToGitLab: false, skipPublishToNuget: true, projectPath: "test/fixture/some.csproj" } as UserConfig,
+        context,
+      );
+    } catch (err) {
+      actualErr = err as AggregateError;
+    }
+
+    expect(actualErr).toBeDefined();
+    expect(actualErr?.errors[0].message).toBe(
+      "skipPublishToNuget is set to true, but publishToGitLab is not set to true so the package will not be published anywhere.",
+    );
+  });
+
   it("should report an error if path to non existing project file is given", async () => {
     process.env.NUGET_TOKEN = "104E2";
 


### PR DESCRIPTION
adds a flag that will skip publishing to NuGet server and only publish to (private) GitLab instance
Contributes to #203